### PR TITLE
Fix "metadata textures and names" on version 1.12.2 and lower

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -455,6 +455,35 @@ describe(`mineflayer-web-inventory tests ${minecraftVersion}`, function () {
     furnace.close()
   })
 
+  // Because versions 1.12 and lower had only one wool item id for all colors
+  // and had the color coded into the item's metadata, it's best to run this test
+  it('Wool textures', async function () {
+    this.timeout(30 * 1000)
+
+    if (mcData.version['<=']('1.12.2')) {
+      bot.chat('/give test wool 3 5\n') // 3 x lime wool
+    } else {
+      bot.chat('/give test lime_wool 3\n') // 3 x lime wool
+    }
+
+    await sleep(2000)
+    assertWindow(window, 0, 'inventory')
+
+    // Check that the item's name is correct
+    if (mcData.version['<=']('1.12.2')) {
+      assertSlotMatch(bot.inventory, window, 36, 'wool', 3)
+    } else {
+      assertSlotMatch(bot.inventory, window, 36, 'lime_wool', 3)
+    }
+
+    // Check that the item's texture is correct (apparently wool's texture changed from 1.11 to 1.12)
+    if (mcData.version['<=']('1.11.2')) {
+      assert.strictEqual(window.slots[36].texture, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABsklEQVR42j2T60oDQQyF54WsvWy72213q3Vt6y8LPpciKIqiKKJQFEVBEPGG9cHifGlPf4SZzGROzkkyoXedWHHXtvyiacVVy7aeMqvee8Z5/zax4Wtu1VvP0uO65Zctq166buyz04aFzefMg6bzyvb+xjb6KPzB4L7jBiiBgOEn+2uWnTU86fAhtcCDna/CLzceU5v8DtwnC2eAuR9XjHuSsSexMwAN2gIqZx2Xgo8UzthjioctfgAFKgRyCRCG5vZBbQEe2SChe95c3VMDYgJ6ukfrVt4kq4w8VHHls4dJelJ3MGoD04Ce3fnItj/7jgx1DFZkpkbcwxQAqGNek3gfQMbUBRVHmslERtXIJUcbf5eLGqi6ao2CoA5FUQcE+rDDZ26oSVAAwdBND2teHM4ExCrqtJqE7GEdyAgdMUGv+i6qAPtMRM2cwYIu0LXARlkwGMHG2xVBqIE6wj0d867NFgyDdIo62Zk29NE+/Q3/A0vqGI+pSRBVHmm61CLvewSWbi9wbC8+e68BDyc/A9ejkZVWMuuD+fAspxIwZx7lBX4aGvVQEyYpZJR+zQXx+oT/Az0n0wHFqucAAAAASUVORK5CYII=')
+    } else {
+      assert.strictEqual(window.slots[36].texture, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABh0lEQVQoUz3SR05DQQwG4DmGQ4Alx6L3JnqNYMddgITQu6iBFYfiGxkhjd7zeOy/eKZMdWP2MiY6MdmN5bvYeWtMn8fMRWw8x9ZLY/Q0Js5i5aEuwVg7yvJ9rD/H0c+QtffRp2jhJuava79jneLh4xhvV9zF2yiKWp9N2aXbOPweFK8+1iKd4s2XsOTByYCuDFq3X+uxurmrKkxMGCqBlTV69j+bRRMix7IM6KR75KSKodt3vFPzFg+OCnF+GhJVaY4hYwHaNMMV/pJ2d9/7YBNjIYTNm7xZEZY1PLBXYKS+TKlARSs8qOlNkvJWr796UGQOhDm2d0YM6hyoLz1o8bgrfoqUjQoaiObHdu2ptv3fj4kDTRUFKi48lj0Bf8J6/SCQ8KMTiSmZZPEDBtJiBpUJwuMh34jqHLSjenF+6lIMNpdKqG2+K/D/YlTXt2TPaF6+BnoUUaInpRNp0GJB9aD04GuAuHwIqdg08y2SZBm/TlroLFhohS2bd6kNClRSkeedqMln+gt0aENEaxLcEwAAAABJRU5ErkJggg==')
+    }
+  })
+
   // TODO: Find another way to test unsupported windows. Using setFailStreak is really unstable
   // Opens and updates an unsupported window. The bot should receive inventory updates instead of updates from an unknown window
   // it('Unsupported window', async function () {

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const fs = require('fs')
 
+const rawMcData = require('minecraft-data')
+
 const windowNamesOrig = {
   inventory: ['minecraft:inventory'],
   chest: ['minecraft:generic_9x3', 'minecraft:chest'],
@@ -31,48 +33,41 @@ function getWindowName (window) {
   }
 
   if (Object.keys(windowNames).includes(window.type)) return window.type
-  return Object.keys(windowNames)[Object.values(windowNames).findIndex(e => e.includes(window.type))]
+  return Object.keys(windowNames)[
+    Object.values(windowNames).findIndex((e) => e.includes(window.type))
+  ]
 }
-
-const metadataToColor = {
-  0: 'white',
-  1: 'orange',
-  2: 'magenta',
-  3: 'light_blue',
-  4: 'yellow',
-  5: 'lime',
-  6: 'pink',
-  7: 'gray',
-  8: 'silver',
-  9: 'cyan',
-  10: 'purple',
-  11: 'blue',
-  12: 'brown',
-  13: 'green',
-  14: 'red',
-  15: 'black'
-}
-
-const coloredItemPaths = {
-  wool: 'wool_colored_',
-  concrete: 'concrete_',
-  concrete_powder: 'concrete_powder_',
-  stained_glass: 'glass_',
-  stained_glass_pane: 'glass_pane_top_'
-}
-
-// planks and sand
 
 function addTexture (mcData, mcAssets, item) {
   if (!item) return item
 
-  if (mcData.version['<=']('1.12.2') && coloredItemPaths[item.name]) {
-    const color = metadataToColor[item.metadata]
-    const textureBase64 = fs.readFileSync(path.join(mcAssets.directory, 'blocks', coloredItemPaths[item.name] + color + '.png')).toString('base64')
-    item.texture = 'data:image/png;base64,' + textureBase64
-  } else {
-    item.texture = mcAssets.textureContent[item.name].texture
+  const blockModels = JSON.parse(fs.readFileSync(path.join(mcAssets.directory, 'blocks_models.json')))
+
+  if (mcData.version['<=']('1.12.2')) {
+    // Fixes the name
+    const itemVariations = mcData.itemsByName[item.name]?.variations ?? mcData.blocksByName[item.name]?.variations
+    if (itemVariations) { item.displayName = itemVariations.find(variation => variation.metadata === item.metadata).displayName }
+
+    // Tries to fix the texture
+    let minecraftName =
+      rawMcData.legacy.pc.items[item.type + ':' + item.metadata].substr('minecraft:'.length)
+    if (minecraftName.includes('[')) minecraftName = minecraftName.substr(0, minecraftName.indexOf['['] - 1)
+
+    if (blockModels[minecraftName]) {
+      const assetName = Object.values(blockModels[minecraftName].textures)[0]
+
+      try {
+        const textureBase64 = fs
+          .readFileSync(path.join(mcAssets.directory, assetName + '.png'))
+          .toString('base64')
+        item.texture = 'data:image/png;base64,' + textureBase64
+      } catch (err) {
+        // It wasn't found. This happens with pistons for example
+      }
+    }
   }
+
+  if (!item.texture) item.texture = mcAssets.textureContent[item.name].texture
 
   return item
 }

--- a/utils.js
+++ b/utils.js
@@ -35,32 +35,40 @@ function getWindowName (window) {
 }
 
 const metadataToColor = {
-  wool: {
-    0: 'white',
-    1: 'orange',
-    2: 'magenta',
-    3: 'light_blue',
-    4: 'yellow',
-    5: 'lime',
-    6: 'pink',
-    7: 'gray',
-    8: 'silver',
-    9: 'cyan',
-    10: 'purple',
-    11: 'blue',
-    12: 'brown',
-    13: 'green',
-    14: 'red',
-    15: 'black'
-  }
+  0: 'white',
+  1: 'orange',
+  2: 'magenta',
+  3: 'light_blue',
+  4: 'yellow',
+  5: 'lime',
+  6: 'pink',
+  7: 'gray',
+  8: 'silver',
+  9: 'cyan',
+  10: 'purple',
+  11: 'blue',
+  12: 'brown',
+  13: 'green',
+  14: 'red',
+  15: 'black'
 }
+
+const coloredItemPaths = {
+  wool: 'wool_colored_',
+  concrete: 'concrete_',
+  concrete_powder: 'concrete_powder_',
+  stained_glass: 'glass_',
+  stained_glass_pane: 'glass_pane_top_'
+}
+
+// planks and sand
 
 function addTexture (mcData, mcAssets, item) {
   if (!item) return item
 
-  if (mcData.version['<=']('1.12.2') && item.name === 'wool') {
-    const woolColor = metadataToColor.wool[item.metadata]
-    const textureBase64 = fs.readFileSync(path.join(mcAssets.directory, 'blocks', 'wool_colored_' + woolColor + '.png')).toString('base64')
+  if (mcData.version['<=']('1.12.2') && coloredItemPaths[item.name]) {
+    const color = metadataToColor[item.metadata]
+    const textureBase64 = fs.readFileSync(path.join(mcAssets.directory, 'blocks', coloredItemPaths[item.name] + color + '.png')).toString('base64')
     item.texture = 'data:image/png;base64,' + textureBase64
   } else {
     item.texture = mcAssets.textureContent[item.name].texture

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,6 @@
+const path = require('path')
+const fs = require('fs')
+
 const windowNamesOrig = {
   inventory: ['minecraft:inventory'],
   chest: ['minecraft:generic_9x3', 'minecraft:chest'],
@@ -31,4 +34,39 @@ function getWindowName (window) {
   return Object.keys(windowNames)[Object.values(windowNames).findIndex(e => e.includes(window.type))]
 }
 
-module.exports = { getWindowName, setFailStreak }
+const metadataToColor = {
+  wool: {
+    0: 'white',
+    1: 'orange',
+    2: 'magenta',
+    3: 'light_blue',
+    4: 'yellow',
+    5: 'lime',
+    6: 'pink',
+    7: 'gray',
+    8: 'silver',
+    9: 'cyan',
+    10: 'purple',
+    11: 'blue',
+    12: 'brown',
+    13: 'green',
+    14: 'red',
+    15: 'black'
+  }
+}
+
+function addTexture (mcData, mcAssets, item) {
+  if (!item) return item
+
+  if (mcData.version['<=']('1.12.2') && item.name === 'wool') {
+    const woolColor = metadataToColor.wool[item.metadata]
+    const textureBase64 = fs.readFileSync(path.join(mcAssets.directory, 'blocks', 'wool_colored_' + woolColor + '.png')).toString('base64')
+    item.texture = 'data:image/png;base64,' + textureBase64
+  } else {
+    item.texture = mcAssets.textureContent[item.name].texture
+  }
+
+  return item
+}
+
+module.exports = { getWindowName, setFailStreak, addTexture }


### PR DESCRIPTION
In 1.12.2 there's only 1 wool item with the color coded into the item's metadata

Something similar should be done with concrete

Also added a test case for this

Closes #28