### PR TITLE
Fix webPath bug

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -102,7 +102,7 @@
   onMount(async () => {
     // Fetch Windows Coordinates
     windowsCoordinates = await (
-      await fetch("/windows/coordinates.json")
+      await fetch("windows/coordinates.json")
     ).json();
 
     const socket = io();


### PR DESCRIPTION
When given a custom path it will stop loading the cords. This fixes that

<details>
<summary>Metod 1 fix (Ignore)</summary>
A fix (without editing the module) is to provide a custom express and app var and then redirect the user

```js
const express = require("express")
const app = express()
app.get("/windows/coordinates.json", (req, res)=> { res.redirect("/inv/windows/coordinates.json") })

//bot login here

inventoryViewer(bot, { webPath: "/inv", express, app})
```
This however is kinda annoying and it shouldn't be like that
</details>


This PR changes the `App.svelte` under `client/src/App.svelte` on line `105` from
```js
await fetch("/windows/coordinates.json")
```
to
```js
await fetch("windows/coordinates.json")
```

Maybe I was doing something wrong to change the path but I don't think so.
Please LMK if I was being dumb or if this is a needed PR

## Why it breaks
The reason this is needed is because when a custom path is used the `coordinates.json` is still pulled from the base URL (`/windows`) and it won't use the custom path (`/inv/windows`)